### PR TITLE
sort array returned from `allTheThings`

### DIFF
--- a/brototype.js
+++ b/brototype.js
@@ -83,16 +83,17 @@
         },
 
         "allTheThings": function() {
-            if (Object.keys) {
-                return Object.keys(this.obj);
-            }
             var key, props = [];
-            for (key in this.obj) {
-                if (this.obj.hasOwnProperty(key)) {
-                    props.push(key);
+            if (Object.keys) {
+                props = Object.keys(this.obj);
+            } else {
+                for (key in this.obj) {
+                    if (this.obj.hasOwnProperty(key)) {
+                        props.push(key);
+                    }
                 }
             }
-            return props;
+            return props.sort();
         },
 
         "iDontAlways": function(methodString) {

--- a/tests.js
+++ b/tests.js
@@ -54,6 +54,13 @@ describe('Bro.allTheThings', function() {
         assert.notEqual(keys.indexOf('foo'), -1);
         assert.notEqual(keys.indexOf('bar'), -1);
     });
+
+    it('should return the keys in order', function () {
+        var a = { 'z': 1, 'y': 2, 'x': 3 },
+            keys = Bro(a).allTheThings();
+        assert.equal(keys[0], 'x');
+        assert.equal(keys[keys.length - 1], 'z');
+    });
 });
 
 describe('Bro.iDontAlways', function() {


### PR DESCRIPTION
Given that objects are unordered, it might be nice for **brototype** to fix it up.
