### PR TITLE
add unit test for 'brototype' alias behavior

### DIFF
--- a/tests.js
+++ b/tests.js
@@ -145,3 +145,9 @@ describe('Bro.braceYourself', function() {
         assert.equal(error, 'an error');
     });
 });
+
+describe('brototype alias', function(){
+  it('kind of basically works', function(){
+    assert.notEqual(Bro.brototype.doYouEven, undefined);
+  });
+});


### PR DESCRIPTION
forgot this in #11.
