### PR TITLE
Fix the README example so that it is doing the same thing as it's counterpart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Or better yet, how about:
 var myURL;
 Bro(app)
     .iDontAlways('config.environment.buildURL')
-    .butWhenIdo(function(val){
-        myURL = val('dev');
+    .butWhenIdo(function(buildURL){
+        myURL = buildURL('dev');
     });
 ```
 


### PR DESCRIPTION
The example was slightly wrong as the first example calls buildURL with a 'dev' string argument and the second one just sets myURL to the buildURL function returned by `butWhenIDo`
