### PR TITLE
Add functions haveYouMet() and haveYouTried() for setting nested values

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,13 @@ var values = Bro(object).iCanHaz(['cheezeburger', 'money', 'beer']);
 ```js
 // set a value
 // overwrite and return true if it exists
-// otherwise set and return false
+// otherwise, set and return false
 var haveMet = Bro(object).haveYouMet('ted.mosby', 'The Architect');
+```
+
+Or, use another alias for setting functions
+```js
+var haveTried = Bro(object).haveYouTried('suit.up', function(){ return 'suited up'; });
 ```
 
 ### Calling nested functions

--- a/README.md
+++ b/README.md
@@ -65,6 +65,14 @@ var value = Bro(object).iCanHaz('cheezeburger');
 var values = Bro(object).iCanHaz(['cheezeburger', 'money', 'beer']);
 ```
 
+### Setting nested members
+```js
+// set a value
+// overwrite and return true if it exists
+// otherwise set and return false
+var haveMet = Bro(object).haveYouMet('ted.mosby', 'The Architect');
+```
+
 ### Calling nested functions
 ```js
 Bro(object)

--- a/brototype.js
+++ b/brototype.js
@@ -137,7 +137,6 @@
             return this.obj.hasOwnProperty(prop);
         },
 
-
         "iDontAlways": function(methodString) {
             var method = this.iCanHaz(methodString);
             return new Bromise(this.obj, method, arguments);

--- a/brototype.js
+++ b/brototype.js
@@ -64,7 +64,7 @@
             }
         },
 
-        "haveYouMet": function(key, value){
+        "haveYouMet": function(key, value) {
             var props = key.split('.');
             var item = this.obj;
             for(var i = 0; i < props.length; i++){
@@ -79,6 +79,10 @@
                 }
                 item = item[prop];
             }
+        },
+
+        "haveYouTried": function(key, value) {
+            return this.haveYouMet(key, value);
         },
 
         "iCanHaz": function(key) {

--- a/brototype.js
+++ b/brototype.js
@@ -64,6 +64,23 @@
             }
         },
 
+        "haveYouMet": function(key, value){
+            var props = key.split('.');
+            var item = this.obj;
+            for(var i = 0; i < props.length; i++){
+                var prop = props[i];
+                if (i === props.length-1) {
+                    var haveMet = Bro(item[prop]).isThatEvenAThing();
+                    item[prop] = value;
+                    return haveMet;
+                }
+                else if (Bro(item[prop]).isThatEvenAThing() === Bro.NOWAY) {
+                    item[prop] = {};
+                }
+                item = item[prop];
+            }
+        },
+
         "iCanHaz": function(key) {
             if (Array.isArray(key)) {
                 var index, value, result = [];
@@ -111,11 +128,11 @@
             }
             return props;
         },
-        
+
         "hasRespect": function(prop) {
             return this.obj.hasOwnProperty(prop);
         },
-        
+
 
         "iDontAlways": function(methodString) {
             var method = this.iCanHaz(methodString);

--- a/tests.js
+++ b/tests.js
@@ -67,6 +67,43 @@ describe('Bro.haveYouMet', function() {
     });
 });
 
+describe('Bro.haveYouTried', function() {
+    it('should be defined', function() {
+        var a = {},
+            bro = Bro(a);
+        assert.notEqual(bro.haveYouTried, undefined);
+    });
+
+    it('should set new property and return true for defined functions', function() {
+        var a = {suitUp: 'do nothing'},
+            bro = Bro(a);
+        assert.equal(bro.haveYouTried('suitUp', function(){ return 'suited up'; }), true);
+        assert.equal(a.suitUp(), 'suited up');
+    });
+
+    it('should set new property and return true for nested defined functions', function() {
+        var a = {suit: {up: 'do nothing'}, lasertag: 'lasertag' },
+            bro = Bro(a);
+        assert.equal(bro.haveYouTried('suit.up', function(){ return 'suited up'; }), true);
+        assert.equal(a.suit.up(), 'suited up');
+        assert.equal(a.lasertag, 'lasertag');
+    });
+
+    it('should set new property and return false for undefinedfunctions', function() {
+        var a = {},
+            bro = Bro(a);
+        assert.equal(bro.haveYouTried('suitUp', function(){ return 'suited up'; }), false);
+        assert.equal(a.suitUp(), 'suited up');
+    });
+
+    it('should set new property and return false for nested undefined functions', function() {
+        var a = {},
+            bro = Bro(a);
+        assert.equal(bro.haveYouTried('suit.up', function(){ return 'suited up'; }), false);
+        assert.equal(a.suit.up(), 'suited up');
+    });
+});
+
 describe('Bro.iCanHaz', function() {
     it('should return the value of the deep property', function() {
         var a = {b: {c: {d: 32}}},

--- a/tests.js
+++ b/tests.js
@@ -29,6 +29,44 @@ describe('Bro.doYouEven', function() {
     });
 });
 
+describe('Bro.haveYouMet', function() {
+    it('should be defined', function() {
+        var a = {},
+            bro = Bro(a);
+        assert.notEqual(bro.haveYouMet, undefined);
+    });
+
+    it('should set new property and return true for defined properties', function() {
+        var a = {foo: 'bar', ted: 'the architect'},
+            bro = Bro(a);
+        assert.equal(bro.haveYouMet('ted', 'the father'), true);
+        assert.equal(a.ted, 'the father');
+    });
+
+    it('should set new property and return true for nested defined properties', function() {
+        var a = {ted: {mosby: 'the professor'}, barney: 'stinson'},
+            bro = Bro(a);
+        assert.equal(bro.haveYouMet('ted.mosby', 'the architect'), true);
+        assert.equal(a.ted.mosby, 'the architect');
+        assert.equal(a.barney, 'stinson');
+    });
+
+    it('should set new property and return false for undefined properties', function() {
+        var a = {foo: 'bar'},
+            bro = Bro(a);
+        assert.equal(bro.haveYouMet('ted', 'that dude'), false);
+        assert.equal(a.ted, 'that dude');
+        assert.equal(a.foo, 'bar');
+    });
+
+    it('should set new property and return false for nested undefined properties', function() {
+        var a = {foo: 'bar'},
+            bro = Bro(a);
+        assert.equal(bro.haveYouMet('ted.mosby', 'that dude'), false);
+        assert.equal(a.ted.mosby, 'that dude');
+    });
+});
+
 describe('Bro.iCanHaz', function() {
     it('should return the value of the deep property', function() {
         var a = {b: {c: {d: 32}}},


### PR DESCRIPTION
Add functions haveYouMet() and haveYouTried() for setting nested values.
I have also updated the test cases and readme file.

Usage:

```js
Bro(obj).haveYouMet('ted.mosby', 'the architect');
console.log(obj.ted.mosby); // 'the architect'
```

Or,
```js
Bro(ted).haveYouTried('suit.up', function(){ return 'suited up Ted'; });
ted.suit.up(); // 'suited up Ted'
```