### PR TITLE
Update README to include the support for square bracket notation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ Well, now you can!
 But what if you have something like this:
 
 ```js
-result2['soap:Envelope']['soap:Body'][0].getResponse[0]['rval'][0].customerId[0]
+app['soap:Envelope']['soap:Body'][0].getResponse[0]['rval'][0].customerId[0]
 ```
 
 We got you covered.
 
 ```js
-if (Bro(result2).doYouEven("soap:Envelope.soap:Body.0.getResponse.0.rval.0.customerId.0")) {
-    var thisVar = result2['soap:Envelope']['soap:Body'][0].getResponse[0]['rval'][0].customerId[0];
+if (Bro(app).doYouEven("soap:Envelope.soap:Body.0.getResponse.0.rval.0.customerId.0")) {
+    var thisVar = app['soap:Envelope']['soap:Body'][0].getResponse[0]['rval'][0].customerId[0];
 }
 ```
 


### PR DESCRIPTION
Updated README to include the support for square bracket notation. I found while using this library that converting it to dot notation works as well, I figure you're just doing a string.split('.') and including square brackets anyway.

Lemme know if there are any gotchas with this, but it seems to work.
