### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,6 @@
 {
   "name": "brototype",
   "main": "brototype.js",
-  "version": "0.0.3",
   "homepage": "http://brototypejs.com/",
   "authors": [
     "Randy Hunt <letsgetrandy@gmail.com>"


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property