### PR TITLE
new setItUp function to set deeply nested properties by the Bro string

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ var values = Bro(object).iCanHaz(['cheezeburger', 'money', 'beer']);
 Bro(object).makeItHappen('cheezeburger.with.pickles');
 ```
 
+```js
+// set a deeply nested property by the Bro string
+Bro(object).makeItHappen('bro.props', 'high five');  // object.bro.props = 'high five'
+```
+
 ### Calling nested functions
 ```js
 Bro(object)

--- a/brototype.js
+++ b/brototype.js
@@ -126,17 +126,17 @@
             var method = this.iCanHaz(methodString);
             return new Bromise(this.obj, method, arguments);
         },
-        "makeItHappen": function(key) {
+        "makeItHappen": function(key, value) {
             var brobj = this.obj;
-            if (this.doYouEven(key) === Bro.NOWAY) {
-                var props = key.split('.');
-                for (var i = 0; i < props.length; ++i) {
-                    if (brobj[props[i]] === undefined) {
-                        brobj[props[i]] = {};
-                    }
-                    brobj = brobj[props[i]];
+            var props = key.split('.');
+            for (var i = 0; i < props.length - 1; ++i) {
+                if (brobj[props[i]] === undefined) {
+                    brobj[props[i]] = {};
                 }
+                brobj = brobj[props[i]];
             }
+            // the deepest key is set to either an empty object or the value provided
+            brobj[props[props.length - 1]] = value === undefined ? {} : value;
         }
     };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brototype",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Bro, do you even Javascript?",
   "main": "brototype.js",
   "scripts": {

--- a/tests.js
+++ b/tests.js
@@ -180,10 +180,24 @@ describe('Bro.makeItHappen', function() {
         assert.deepEqual(expected, obj);
     });
 
-    it('should add properties to object, in extending deeper nested objects', function() {
+    it('should add properties to object, extending deeper nested objects', function() {
         expected = { "foo": { "bar": { "stuff": { "and": { "things": {} } } } } };
         var bro = Bro(obj);
         bro.makeItHappen('foo.bar.stuff.and.things');
+        assert.deepEqual(expected, obj);
+    });
+
+    it('should set existing deeply nested properties on an object', function() {
+        expected = { "foo": { "bar": 'awesome' } };
+        var bro = Bro(obj);
+        bro.makeItHappen('foo.bar', 'awesome');
+        assert.deepEqual(expected, obj);
+    });
+
+    it('should create new properties, then set them, as needed', function() {
+        expected = { "foo": { "bar": { "stuff": { "and": { "things": 'super awesome' } } } } };
+        var bro = Bro(obj);
+        bro.makeItHappen('foo.bar.stuff.and.things', 'super awesome');
         assert.deepEqual(expected, obj);
     });
 });


### PR DESCRIPTION
I found myself stuck trying to set deeply nested properties when using a Bro string, and `iCanHaz` only gave me the value, not a reference that I could set.  So here's a function that can do that.

Also bumped the version number for ya in case you decide to merge it.