### PR TITLE
Added graceful check for undefined objects & fixed bad = comparison

### DIFF
--- a/brototype.js
+++ b/brototype.js
@@ -76,10 +76,12 @@
             }
             var props = key.split('.'),
                 item = this.obj;
-            for (var i = 0; i < props.length; i++) {
-                item = item[props[i]];
-                if (Bro(item).isThatEvenAThing() === Bro.NOWAY) {
-                    return item;
+            if (item) {
+                for (var i = 0; i < props.length; i++) {
+                    item = item[props[i]];
+                    if (Bro(item).isThatEvenAThing() === Bro.NOWAY) {
+                        return item;
+                    }
                 }
             }
             return item;

--- a/brototype.js
+++ b/brototype.js
@@ -68,9 +68,8 @@
             if (Array.isArray(key)) {
                 var index, value, result = [];
                 for (index in key) {
-                    if (value === this.iCanHaz(key[index])) {
-                        result.push(value);
-                    }
+                    value = this.iCanHaz(key[index])
+                    result.push(value);
                 }
                 return result;
             }

--- a/brototype.js
+++ b/brototype.js
@@ -68,7 +68,7 @@
             if (Array.isArray(key)) {
                 var index, value, result = [];
                 for (index in key) {
-                    if (value = this.iCanHaz(key[index])) {
+                    if (value === this.iCanHaz(key[index])) {
                         result.push(value);
                     }
                 }

--- a/brototype.js
+++ b/brototype.js
@@ -68,14 +68,14 @@
             if (Array.isArray(key)) {
                 var index, value, result = [];
                 for (index in key) {
-                    value = this.iCanHaz(key[index])
+                    value = this.iCanHaz(key[index]);
                     result.push(value);
                 }
                 return result;
             }
             var props = key.split('.'),
                 item = this.obj;
-            if (item) {
+            if (typeof item !== "undefined") {
                 for (var i = 0; i < props.length; i++) {
                     item = item[props[i]];
                     if (Bro(item).isThatEvenAThing() === Bro.NOWAY) {

--- a/tests.js
+++ b/tests.js
@@ -27,6 +27,12 @@ describe('Bro.doYouEven', function() {
             bro = Bro(a);
         assert.equal(bro.doYouEven('bar'), false);
     });
+
+    it('should fail gracefully if the object is not defined', function() {
+        var a = undefined,
+            bro = Bro(a);
+        assert.equal(bro.doYouEven('foo.bar'), false);
+    });
 });
 
 describe('Bro.iCanHaz', function() {


### PR DESCRIPTION
When calling Brototype functions on an object that doesn’t exist causes
a stack error. This checks for it and gracefully handles the failure by
simply returning ‘undefined’.