### PR TITLE
Added support to doYouEven() for checking an array of properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ if(Bro(object).doYouEven('lift') === Bro.TOTALLY) {
 }
 ```
 
+Or check for multiple nested members by passing an array of paths
+```js
+if (Bro(object)
+    .doYouEven(['property.one', 'property.two']) {
+    // returns true if all referenced properties exist
+    console.log(app.property.one, app.property.two);
+})
+```
+
 Or, just use a callback...
 ```js
 Bro(object)

--- a/README.md
+++ b/README.md
@@ -69,12 +69,12 @@ if(Bro(object).doYouEven('lift') === Bro.TOTALLY) {
 }
 ```
 
-Or check for multiple nested members by passing an array of paths
+Or, ensure that multiple nested members exist by passing an array of paths
 ```js
 if (Bro(object)
     .doYouEven(['property.one', 'property.two']) {
     // returns true if all referenced properties exist
-    console.log(app.property.one, app.property.two);
+    console.log(object.property.one, object.property.two);
 })
 ```
 
@@ -185,7 +185,7 @@ before submitting your pull request.
 
 ## Bro-tie
 For the brofessional. Want to use Brototype.js but it's too bro for your work
-environment? Just give it the [Bro-tie](http://brotie.jdauriemma.com) treatment
+environment? Just give it the [Bro-tie](http://pepperthecat.github.io/brotie/) treatment
 so you can bro down at the office!
 Alias some or all of the names to make your boss happy.
 

--- a/brototype.js
+++ b/brototype.js
@@ -53,14 +53,28 @@
         },
 
         "doYouEven": function(key, options) {
-            var optionsBro = Bro(options || {}),
-                bro = this.iCanHaz(key);
-            if (Bro(bro).isThatEvenAThing() === Bro.TOTALLY) {
-                optionsBro.iDontAlways('forSure').butWhenIdo();
-                return Bro.TOTALLY;
+            var optionsBro = Bro(options || {});
+            if (key instanceof Array) {
+                var self = this;
+                if (key.every(function(k) {
+                        var bro = self.iCanHaz(k);
+                        return (Bro(bro).isThatEvenAThing() === Bro.TOTALLY);
+                    })) {
+                    optionsBro.iDontAlways('forSure').butWhenIdo();
+                    return Bro.TOTALLY;
+                } else {
+                    optionsBro.iDontAlways('sorryBro').butWhenIdo();
+                    return Bro.NOWAY;
+                }
             } else {
-                optionsBro.iDontAlways('sorryBro').butWhenIdo();
-                return Bro.NOWAY;
+                var bro = this.iCanHaz(key);
+                if (Bro(bro).isThatEvenAThing() === Bro.TOTALLY) {
+                    optionsBro.iDontAlways('forSure').butWhenIdo();
+                    return Bro.TOTALLY;
+                } else {
+                    optionsBro.iDontAlways('sorryBro').butWhenIdo();
+                    return Bro.NOWAY;
+                }
             }
         },
 

--- a/brototype.js
+++ b/brototype.js
@@ -54,27 +54,19 @@
 
         "doYouEven": function(key, options) {
             var optionsBro = Bro(options || {});
-            if (key instanceof Array) {
-                var self = this;
-                if (key.every(function(k) {
-                        var bro = self.iCanHaz(k);
-                        return (Bro(bro).isThatEvenAThing() === Bro.TOTALLY);
-                    })) {
-                    optionsBro.iDontAlways('forSure').butWhenIdo();
-                    return Bro.TOTALLY;
-                } else {
-                    optionsBro.iDontAlways('sorryBro').butWhenIdo();
-                    return Bro.NOWAY;
-                }
+            if (!(key instanceof Array)) {
+                key = [key];
+            }
+            var self = this;
+            if (key.every(function(k) {
+                    var bro = self.iCanHaz(k);
+                    return (Bro(bro).isThatEvenAThing() === Bro.TOTALLY);
+                })) {
+                optionsBro.iDontAlways('forSure').butWhenIdo();
+                return Bro.TOTALLY;
             } else {
-                var bro = this.iCanHaz(key);
-                if (Bro(bro).isThatEvenAThing() === Bro.TOTALLY) {
-                    optionsBro.iDontAlways('forSure').butWhenIdo();
-                    return Bro.TOTALLY;
-                } else {
-                    optionsBro.iDontAlways('sorryBro').butWhenIdo();
-                    return Bro.NOWAY;
-                }
+                optionsBro.iDontAlways('sorryBro').butWhenIdo();
+                return Bro.NOWAY;
             }
         },
 

--- a/tests.js
+++ b/tests.js
@@ -22,6 +22,13 @@ describe('Bro.doYouEven', function() {
         assert.equal(bro.doYouEven('foo.bar'), true);
     });
 
+    it('should return true for more than one nested property', function() {
+        var a = {b: {c: 'foo'},d: {e: 'bar'}},
+            bro = Bro(a);
+        assert.equal(bro.doYouEven(['b.c', 'd.x']), false);
+        assert.equal(bro.doYouEven(['b.c', 'd.e']), true);
+    });
+
     it('should return false for undefined properties', function() {
         var a = {foo: 'bar'},
             bro = Bro(a);


### PR DESCRIPTION
Pretty self-explanatory, but now with `doYouEven()` you can pass an array of properties to check:

    bro.doYouEven(['b.c', 'd.e'])

This will return `true` only if all properties exist.