### PR TITLE
brototype should works in CMD even angular is defined

### DIFF
--- a/brototype.js
+++ b/brototype.js
@@ -163,12 +163,14 @@
             define(function() {
                 return Bro;
             });
-        } else if (typeof(angular) !== 'undefined') {
-            angular.module('brototype', []).factory('Bro', function() { return Bro; });
         } else if (typeof module !== 'undefined' && module.exports) {
             module.exports = Bro;
         } else if (typeof window !== 'undefined') {
             window.Bro = Bro;
+        }
+
+        if (typeof(angular) !== 'undefined') {
+            angular.module('brototype', []).factory('Bro', function() { return Bro; });
         }
     })();
 })();


### PR DESCRIPTION
Many angularjs developer are using compile system like browserify or webpack on a daily basis now.
should be able to require brototype 'outside' angular